### PR TITLE
Fix parent dir create

### DIFF
--- a/Sources/Zip.swift
+++ b/Sources/Zip.swift
@@ -114,18 +114,18 @@ public class Zip {
 					}
 				}
 				else {
-                    var parentDirectoryPathArray = fullPath.characters.split(separator: "/").map(String.init)
+					var parentDirectoryPathArray = fullPath.characters.split(separator: "/").map(String.init)
 					parentDirectoryPathArray.removeLast()
-                    
-                    let hasRootPrefix = fullPath.hasPrefix("/")
-                    let parentDirectoryPath: String
-                    if hasRootPrefix {
-                        parentDirectoryPath = "/" + parentDirectoryPathArray.joined(separator: "/")
-                    } else {
-                        parentDirectoryPath = parentDirectoryPathArray.joined(separator: "/")
-                    }
 					
-                    let parentDirectory = Dir(parentDirectoryPath)
+					let hasRootPrefix = fullPath.hasPrefix("/")
+					let parentDirectoryPath: String
+					if hasRootPrefix {
+						parentDirectoryPath = "/" + parentDirectoryPathArray.joined(separator: "/")
+					} else {
+						parentDirectoryPath = parentDirectoryPathArray.joined(separator: "/")
+					}
+					
+					let parentDirectory = Dir(parentDirectoryPath)
 					try parentDirectory.create()
 
 				}

--- a/Sources/Zip.swift
+++ b/Sources/Zip.swift
@@ -114,9 +114,18 @@ public class Zip {
 					}
 				}
 				else {
-					var parentDirectoryPathArray = fullPath.characters.split(separator: "/").map(String.init)
+                    var parentDirectoryPathArray = fullPath.characters.split(separator: "/").map(String.init)
 					parentDirectoryPathArray.removeLast()
-					let parentDirectory = Dir(parentDirectoryPathArray.joined(separator: "/"))
+                    
+                    let hasRootPrefix = fullPath.hasPrefix("/")
+                    let parentDirectoryPath: String
+                    if hasRootPrefix {
+                        parentDirectoryPath = "/" + parentDirectoryPathArray.joined(separator: "/")
+                    } else {
+                        parentDirectoryPath = parentDirectoryPathArray.joined(separator: "/")
+                    }
+					
+                    let parentDirectory = Dir(parentDirectoryPath)
 					try parentDirectory.create()
 
 				}


### PR DESCRIPTION
Previously, if the parent dir path starts with a `/`, it may be ignored.
As a result, a useless copy of the dir hierarchy will be created based
on the current working directory of the process.

The fix checks first whether there is a `/` prefix, and if there is, the
result path will be prefixed with a `/` to preserve the original root of
the file path.